### PR TITLE
Fix connection overlay sometime not showing + Queue updates to tracker when disconnected

### DIFF
--- a/APRandomizerMain.cs
+++ b/APRandomizerMain.cs
@@ -890,7 +890,7 @@ namespace MessengerRando
             if (ArchipelagoClient.DialogQueue.Count > 0)
             {
                 var message = (string)ArchipelagoClient.DialogQueue.Dequeue();
-                logger.Log(message);
+                Console.WriteLine(message);
                 DialogChanger.CreateDialogBox(message);
             }
 

--- a/APRandomizerMain.cs
+++ b/APRandomizerMain.cs
@@ -888,8 +888,10 @@ namespace MessengerRando
             {
                 apTextDisplay8 = Object.Instantiate(self.hud_8.coinCount, self.hud_8.gameObject.transform);
                 apTextDisplay16 = Object.Instantiate(self.hud_16.coinCount, self.hud_16.gameObject.transform);
-                apTextDisplay8.transform.Translate(0f, -110f, 0f);
-                apTextDisplay16.transform.Translate(0f, -110f, 0f);
+                apTextDisplay8.rectTransform.Translate(0f, -110f, 0f);
+                apTextDisplay16.rectTransform.Translate(0f, -110f, 0f);
+                apTextDisplay8.rectTransform.sizeDelta = new Vector2(apTextDisplay8.rectTransform.sizeDelta.x + 100f, apTextDisplay8.rectTransform.sizeDelta.y);
+                apTextDisplay16.rectTransform.sizeDelta = new Vector2(apTextDisplay16.rectTransform.sizeDelta.x + 100f, apTextDisplay16.rectTransform.sizeDelta.y);
                 apTextDisplay16.fontSize = apTextDisplay8.fontSize = UserConfig.StatusTextSize;
                 apTextDisplay16.alignment = apTextDisplay8.alignment = TextAlignmentOptions.TopRight;
                 apTextDisplay16.enableWordWrapping = apTextDisplay8.enableWordWrapping = true;
@@ -897,8 +899,8 @@ namespace MessengerRando
 
                 apMessagesDisplay8 = Object.Instantiate(self.hud_8.coinCount, self.hud_8.gameObject.transform);
                 apMessagesDisplay16 = Object.Instantiate(self.hud_16.coinCount, self.hud_16.gameObject.transform);
-                apMessagesDisplay8.transform.Translate(0f, -200f, 0f);
-                apMessagesDisplay16.transform.Translate(0f, -200f, 0f);
+                apMessagesDisplay8.rectTransform.Translate(0f, -200f, 0f);
+                apMessagesDisplay16.rectTransform.Translate(0f, -200f, 0f);
                 apMessagesDisplay16.fontSize = apMessagesDisplay8.fontSize = UserConfig.MessageTextSize;
                 apMessagesDisplay16.alignment = apMessagesDisplay8.alignment = TextAlignmentOptions.BottomRight;
                 apMessagesDisplay16.enableWordWrapping = apMessagesDisplay16.enableWordWrapping = true;

--- a/APRandomizerMain.cs
+++ b/APRandomizerMain.cs
@@ -60,7 +60,6 @@ namespace MessengerRando
             randoStateManager = new RandomizerStateManager();
 
             trackerManager = new TrackerManager();
-            ItemsAndLocationsHandler.TrackerManager = trackerManager;
             RandoPortalManager.TrackerManager = trackerManager;
             RandoLevelManager.TrackerManager = trackerManager;
 
@@ -877,8 +876,41 @@ namespace MessengerRando
             TrapManager.TrapTimer += Time.deltaTime;
             if (!(updateTimer >= UpdateTime)) return;
             updateTimer = 0;
-            ArchipelagoClient.UpdateArchipelagoState();
+            UpdateArchipelagoState();
             apMessagesDisplay16.text = apMessagesDisplay8.text = ArchipelagoClient.UpdateMessagesText();
+        }
+
+        public void UpdateArchipelagoState()
+        {
+            while (ArchipelagoClient.ItemQueue.Count > 0)
+            {
+                ItemsAndLocationsHandler.Unlock((long)ArchipelagoClient.ItemQueue.Dequeue());
+            }
+
+            if (ArchipelagoClient.DialogQueue.Count > 0)
+            {
+                var message = (string)ArchipelagoClient.DialogQueue.Dequeue();
+                logger.Log(message);
+                DialogChanger.CreateDialogBox(message);
+            }
+
+            TrapManager.UpdateTrapStatus();
+            if (ArchipelagoClient.Offline) return;
+            if (!ArchipelagoClient.Authenticated)
+            {
+                Console.WriteLine("Attempting to reconnect to Archipelago Server...");
+                ThreadPool.QueueUserWorkItem(_ => ArchipelagoClient.ConnectAsync());
+                return;
+            }
+
+            if (ArchipelagoClient.ServerData.Index < ArchipelagoClient.Session.Items.AllItemsReceived.Count)
+            {
+                ItemsAndLocationsHandler.UnlockItems();
+                return;
+            }
+
+            if (!ItemsAndLocationsHandler.Synced) ItemsAndLocationsHandler.ReSync();
+            if (!trackerManager.Synced) trackerManager.ReSync();
         }
 
         private void InGameHud_OnGUI(On.InGameHud.orig_OnGUI orig, InGameHud self)

--- a/Archipelago/ArchipelagoClient.cs
+++ b/Archipelago/ArchipelagoClient.cs
@@ -101,13 +101,6 @@ namespace MessengerRando.Archipelago
             return session;
         }
 
-        private static ArchipelagoSession CreateSession(Uri uri)
-        {
-            var session = ArchipelagoSessionFactory.CreateSession(uri);
-            SetupSession(session);
-            return session;
-        }
-
         private static void SetupSession(ArchipelagoSession session)
         {
             session.MessageLog.OnMessageReceived += OnMessageReceived;
@@ -122,23 +115,6 @@ namespace MessengerRando.Archipelago
             {
                 roomUpdate = true;
             }
-        }
-
-        public static string Connect(Uri uri)
-        {
-            if (Authenticated) return "already connected";
-
-            try
-            {
-                Session = CreateSession(uri);
-            }
-            catch (Exception e)
-            {
-                Console.WriteLine($"Error: {e}");
-                return e.ToString();
-            }
-
-            return TryConnect();
         }
 
         public static string Connect()
@@ -194,6 +170,7 @@ namespace MessengerRando.Archipelago
                     ServerData.SlotData = success.SlotData;
                 ServerData.SeedName = Session.RoomState.Seed;
                 Authenticated = true;
+                roomUpdate = true;
 
                 try
                 {
@@ -201,12 +178,13 @@ namespace MessengerRando.Archipelago
                 }
                 catch (Exception e)
                 {
-                    Console.WriteLine(e);
+                    logger.Exception(e);
                     outputText =
                         "Something went wrong.\n" +
                         "Please submit a bug report with the log.txt, " +
                         "which can be found by the game executable.";
                     Authenticated = false;
+                    roomUpdate = true;
                     Disconnect();
                     return outputText;
                 }
@@ -230,6 +208,7 @@ namespace MessengerRando.Archipelago
                 Console.WriteLine(outputText);
 
                 Authenticated = false;
+                roomUpdate = true;
                 Disconnect();
             }
 
@@ -409,6 +388,7 @@ namespace MessengerRando.Archipelago
             Session?.Socket.Disconnect();
             Session = null;
             Authenticated = false;
+            roomUpdate = true;
             attemptingConnection = false;
             DialogQueue = new Queue();
             ItemQueue = new Queue();
@@ -533,7 +513,7 @@ namespace MessengerRando.Archipelago
             }
             else if (HasConnected)
             {
-                statusText = "Disconnected from Archipelago server.";
+                statusText = "Disconnected from Archipelago server\nWill attempt to reconnect...";
             }
             return statusText;
         }

--- a/Archipelago/ArchipelagoClient.cs
+++ b/Archipelago/ArchipelagoClient.cs
@@ -395,38 +395,6 @@ namespace MessengerRando.Archipelago
             messageQueue = new Queue();
         }
 
-        public static void UpdateArchipelagoState()
-        {
-            while (ItemQueue.Count > 0)
-            {
-                ItemsAndLocationsHandler.Unlock((long)ItemQueue.Dequeue());
-            }
-
-            if (DialogQueue.Count > 0)
-            {
-                var message = (string)DialogQueue.Dequeue();
-                Console.WriteLine(message);
-                DialogChanger.CreateDialogBox(message);
-            }
-
-            TrapManager.UpdateTrapStatus();
-            if (Offline) return;
-            if (!Authenticated)
-            {
-                Console.WriteLine("Attempting to reconnect to Archipelago Server...");
-                ThreadPool.QueueUserWorkItem(_ => ConnectAsync());
-                return;
-            }
-
-            if (ServerData.Index < Session.Items.AllItemsReceived.Count)
-            {
-                ItemsAndLocationsHandler.UnlockItems();
-                return;
-            }
-            if (!ItemsAndLocationsHandler.Synced)
-                ItemsAndLocationsHandler.ReSync();
-        }
-
         public static void UpdateClientStatus(ArchipelagoClientState newState)
         {
             Console.WriteLine($"Updating client status to {newState}");

--- a/Archipelago/ArchipelagoClient.cs
+++ b/Archipelago/ArchipelagoClient.cs
@@ -178,7 +178,7 @@ namespace MessengerRando.Archipelago
                 }
                 catch (Exception e)
                 {
-                    logger.Exception(e);
+                    Console.WriteLine(e);
                     outputText =
                         "Something went wrong.\n" +
                         "Please submit a bug report with the log.txt, " +

--- a/Archipelago/ItemsAndLocationsHandler.cs
+++ b/Archipelago/ItemsAndLocationsHandler.cs
@@ -22,7 +22,6 @@ namespace MessengerRando.Archipelago
         public const long BaseOffset = 0xADD_000;
 
         public static bool Synced;
-        public static TrackerManager TrackerManager;
 
         /// <summary>
         /// Builds the item and lookup dictionaries for converting to and from AP checks. Will always make every location
@@ -547,7 +546,6 @@ namespace MessengerRando.Archipelago
         {
             Synced = true;
             ArchipelagoClient.SyncEvents();
-            TrackerManager.ReconciliateUnlockedPortals();
 
             var receivedItems = new Dictionary<long, int>();
 

--- a/Archipelago/TrackerManager.cs
+++ b/Archipelago/TrackerManager.cs
@@ -42,16 +42,16 @@ namespace MessengerRando.Archipelago
         {
             if (visitedEntrances.Contains(entrance)) return;
 
-        if (ArchipelagoClient.Offline) return;
-        if (!ArchipelagoClient.Authenticated)
-        {
-            Synced = false;
-            unsentVisitedEntrances.Add(entrance);
-            return;
-        }
+            if (ArchipelagoClient.Offline) return;
+            if (!ArchipelagoClient.Authenticated)
+            {
+                Synced = false;
+                unsentVisitedEntrances.Add(entrance);
+                return;
+            }
 
-        visitedEntrances = ArchipelagoClient.Session.DataStorage[Scope.Slot, "VisitedEntrances"].To<List<string>>() ?? [];
-        if (visitedEntrances.Contains(entrance)) return;
+            visitedEntrances = ArchipelagoClient.Session.DataStorage[Scope.Slot, "VisitedEntrances"].To<List<string>>() ?? [];
+            if (visitedEntrances.Contains(entrance)) return;
 
             Console.WriteLine("Adding visited entrance: " + entrance);
             visitedEntrances.Add(entrance);
@@ -64,7 +64,7 @@ namespace MessengerRando.Archipelago
         public void ReconciliateUnlockedPortals()
         {
             if (ArchipelagoClient.Offline) return;
-                if (!ArchipelagoClient.Authenticated)
+            if (!ArchipelagoClient.Authenticated)
             {
                 Synced = false;
                 needsUnlockedPortalsReconciliation = true;

--- a/Archipelago/TrackerManager.cs
+++ b/Archipelago/TrackerManager.cs
@@ -9,28 +9,67 @@ namespace MessengerRando.Archipelago
     public class TrackerManager
     {
 
-        private List<string> VisitedEntrances = [];
+        private List<string> visitedEntrances = [];
+
+        public bool Synced { get; private set; } = false;
+
+        private readonly HashSet<string> unsentVisitedEntrances = [];
+        private bool needsUnlockedPortalsReconciliation = true;
+        private ELevel lastKnownCurrentRegion = ELevel.NONE;
+
+        public void ReSync()
+        {
+            Synced = true;
+            Console.WriteLine("Re-syncing tracker data from Data Storage");
+
+            visitedEntrances = ArchipelagoClient.Session.DataStorage[Scope.Slot, "VisitedEntrances"].To<List<string>>() ?? [];
+            unsentVisitedEntrances.RemoveWhere(visitedEntrances.Contains);
+            if (unsentVisitedEntrances.Count > 0)
+            {
+                Console.WriteLine($"Adding visited entrances:\n\t{string.Join("\n\t", [.. unsentVisitedEntrances])}");
+                visitedEntrances.AddRange(unsentVisitedEntrances);
+                visitedEntrances.Sort();
+                ArchipelagoClient.Session.DataStorage[Scope.Slot, "VisitedEntrances"] = visitedEntrances;
+                unsentVisitedEntrances.Clear();
+            }
+
+            if (needsUnlockedPortalsReconciliation) ReconciliateUnlockedPortals();
+            if (lastKnownCurrentRegion != ELevel.NONE) SetCurrentRegion(lastKnownCurrentRegion);
+        }
 
 
         public void AddVisitedEntrance(string entrance)
         {
-            if (VisitedEntrances.Contains(entrance)) return;
+            if (visitedEntrances.Contains(entrance)) return;
 
-            if (!ArchipelagoClient.Authenticated) return;
-            VisitedEntrances = ArchipelagoClient.Session.DataStorage[Scope.Slot, "VisitedEntrances"].To<List<string>>() ?? [];
-            if (VisitedEntrances.Contains(entrance)) return;
+        if (ArchipelagoClient.Offline) return;
+        if (!ArchipelagoClient.Authenticated)
+        {
+            Synced = false;
+            unsentVisitedEntrances.Add(entrance);
+            return;
+        }
+
+        visitedEntrances = ArchipelagoClient.Session.DataStorage[Scope.Slot, "VisitedEntrances"].To<List<string>>() ?? [];
+        if (visitedEntrances.Contains(entrance)) return;
 
             Console.WriteLine("Adding visited entrance: " + entrance);
-            VisitedEntrances.Add(entrance);
-            VisitedEntrances.Sort();
-            ArchipelagoClient.Session.DataStorage[Scope.Slot, "VisitedEntrances"] = VisitedEntrances;
+            visitedEntrances.Add(entrance);
+            visitedEntrances.Sort();
+            ArchipelagoClient.Session.DataStorage[Scope.Slot, "VisitedEntrances"] = visitedEntrances;
 
             return;
         }
 
         public void ReconciliateUnlockedPortals()
         {
-            if (!ArchipelagoClient.Authenticated) return;
+            if (ArchipelagoClient.Offline) return;
+                if (!ArchipelagoClient.Authenticated)
+            {
+                Synced = false;
+                needsUnlockedPortalsReconciliation = true;
+                return;
+            }
 
             var unlockedPortals = RandoPortalManager.UnlockedPortals;
             unlockedPortals.UnionWith(ArchipelagoClient.Session.DataStorage[Scope.Slot, "UnlockedPortals"].To<List<string>>() ?? []);
@@ -39,6 +78,19 @@ namespace MessengerRando.Archipelago
             unlockedPortalsList.Sort();
             Console.WriteLine($"Updating unlocked portals with Data Storage. Unlocked portals are\n\t{string.Join("\n\t", [.. unlockedPortalsList])}");
             ArchipelagoClient.Session.DataStorage[Scope.Slot, "UnlockedPortals"] = unlockedPortalsList;
+        }
+
+        public void SetCurrentRegion(ELevel level)
+        {
+            if (ArchipelagoClient.Offline) return;
+            if (!ArchipelagoClient.Authenticated)
+            {
+                Synced = false;
+                lastKnownCurrentRegion = level;
+                return;
+            }
+
+            ArchipelagoClient.Session.DataStorage[Scope.Slot, "CurrentRegion"] = level.ToString();
         }
     }
 }


### PR DESCRIPTION
Feedback from https://discord.com/channels/731205301247803413/1090822939697500243/1532474440217268395

It seems like sometimes, the mod does not send updates to the tracker. My best guess is that player was disconnected from the server, but was not aware of it. 

The overlay telling players they're connected is currently bugged. When the mod first connect, the overlay does not show. It only gets its first update after messages are received from the server. I noticed that while testing/playing solo seeds, it can take a long time for it to show up. That would explain how players are not aware their mod is disconnected. In this specific case, they were in a room with only one other player, so not much server chatting.

So this fixes the overlay, now it will also update when the client connect/disconnect. The `TrackerManager` will also keep a statea state of the updates that could not be sent while the client was disconnected, so they can be sent when the client reconnects.

Last thing, I moved `UpdateArchipelagoState` into `APRandomizerMain` instead of it being in `ArchipelagoClient`. `ArchipelagoClient` is currently the center of the spaghetti the mod is. Everything talks to it, and it talks to everything. My goal with the change is to eventually only have stuff talking to the client, and the client talking to mostly nothing (only external stuff like the `ArchipelagoSession`, `DeathLinkInterface`, etc). The client in itself can't do much anyway since Unity is single-threaded. It can only queue stuff and wait for the update to pick it up.